### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @Banno/dev-advocates


### PR DESCRIPTION
# Summary

Adding `CODEOWNERS` file per Ross Baker's direction in https://banno.slack.com/archives/C025264R2/p1694545726527329

I'm using the instructions from https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file.

## Notes

To reduce the likelihood that something terrible would happen with cross-org stuff in GitHub, I decided to do this (for now...we can change later):

- For `Banno` org repos, we'll use `@Banno/dev-advocates` as the CODEOWNERS.
- For `jkhy` org repos, we'll use `@jkhy/developer-relations` as the CODEOWNERS.

Again, I don't know exactly what happens if we mix-and-match so I'm keeping them separate for now. Later research will figure out whether or not we can consolidate down to a single GitHub team for us as CODEOWNERS.
